### PR TITLE
Include node ports in hash

### DIFF
--- a/src/shared/data/www/cgi-bin/meshchatlib.pm
+++ b/src/shared/data/www/cgi-bin/meshchatlib.pm
@@ -246,10 +246,10 @@ sub pi_node_list {
         if ( lc($local_node) eq lc($node) ) { next; }
 
         if ( $port == 8080 ) {
-            push( @$nodes, { platform => 'node', node => lc($node) } );
+            push( @$nodes, { platform => 'node', node => lc($node), port => $port } );
         }
         else {
-            push( @$nodes, { platform => 'pi', node => lc($node) } );
+            push( @$nodes, { platform => 'pi', node => lc($node), port => $port } );
         }
     }
 


### PR DESCRIPTION
When using a non-standard port for meshchat, I found that $port was not being set correctly and meshchatsync was using port 80 always. The pi_node_list subroutine only sets the 'platform' and 'node' keys in the hash references based on the port number, but it doesn't include the 'port' key in the hash reference.